### PR TITLE
BoundedBlockingQueue

### DIFF
--- a/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
+++ b/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
@@ -1,6 +1,7 @@
 ﻿using PBase.Collections;
 using PBase.Test.Support;
 using System;
+using System.Collections;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,7 +22,7 @@ namespace PBase.Test.Collections
         {
             public int Value { get; set; }
         }
-        
+
         [Fact]
         void TestBoundedBlockingQueueCreation()
         {
@@ -156,7 +157,7 @@ namespace PBase.Test.Collections
             Assert.Equal(2, bbq.Count);
 
             bbq.Enqueue(new TestQueueItem { Value = 300 });
-            
+
             Task.Run(async () =>
             {
                 await Task.Delay(1000); //have to wait as new item will be enqueued immediately after clearing
@@ -171,7 +172,7 @@ namespace PBase.Test.Collections
             Assert.False(result);
             Assert.Null(qItem);
 
-            await Task.Delay(1000);
+            await Task.Delay(1500);
             Assert.Equal(1, bbq.Count);
             var item400 = bbq.Dequeue();
             Assert.Equal(400, item400.Value);
@@ -205,6 +206,12 @@ namespace PBase.Test.Collections
             var resTryDeq = bbq.TryDequeue(out var itemDequeue);
             Assert.False(resTryDeq);
             Assert.Null(itemDequeue);
+
+            Assert.Throws<ObjectDisposedException>(() => bbq.Contains(new TestQueueItem { Value = 1000 }));
+            Assert.Throws<ObjectDisposedException>(() => bbq.CopyTo(new TestQueueItem[3], 0));
+
+            Assert.Throws<ObjectDisposedException>(() => bbq.GetEnumerator());
+            Assert.Throws<ObjectDisposedException>(() => (bbq as IEnumerable).GetEnumerator());
         }
 
         [Fact]
@@ -359,7 +366,7 @@ namespace PBase.Test.Collections
                 }
             });
 
-            await Task.Delay(1000);
+            await Task.Delay(1500);
 
             bbq.Enqueue(new TestQueueItem { Value = 200 });
 

--- a/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
+++ b/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
@@ -365,9 +365,7 @@ namespace PBase.Test.Collections
                     exceptionThrown = true;
                 }
             });
-
-            await Task.Delay(1500);
-
+            
             bbq.Enqueue(new TestQueueItem { Value = 200 });
 
             await Task.Delay(2000);

--- a/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
+++ b/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
@@ -370,7 +370,7 @@ namespace PBase.Test.Collections
 
             bbq.Enqueue(new TestQueueItem { Value = 200 });
 
-            await Task.Delay(1000);
+            await Task.Delay(2000);
 
             Assert.Equal(1, bbq.Count);
             Assert.Equal(200, item200.Value);

--- a/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
+++ b/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
@@ -1,0 +1,99 @@
+﻿using PBase.Collections;
+using PBase.Test.Support;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PBase.Test.Collections
+{
+    public class BoundedBlockingQueueTests : BaseUnitTest
+    {
+        public BoundedBlockingQueueTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        private class TestQueueItem
+        {
+            public int Value { get; set; }
+        }
+
+#pragma warning disable xUnit2013 // Do not use equality check to check for collection size.
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+        [Fact]
+        void TestBoundedBlockingQueueCreation()
+        {
+            BoundedBlockingQueue<TestQueueItem> bbq = new BoundedBlockingQueue<TestQueueItem>(5);
+
+            Assert.NotNull(bbq);
+
+            Assert.Equal(5, bbq.Size);
+            Assert.Equal(0, bbq.Count);
+        }
+
+        [Fact]
+        async void TestBoundedBlockingQueueEnqueue()
+        {
+            BoundedBlockingQueue<TestQueueItem> bbq = new BoundedBlockingQueue<TestQueueItem>(2);
+            bbq.Enqueue(new TestQueueItem { Value = 100 });
+            bbq.Enqueue(new TestQueueItem { Value = 200 });
+
+            Assert.Equal(2, bbq.Size);
+            Assert.Equal(2, bbq.Count);
+
+            Assert.Throws<TimeoutException>(() => bbq.Enqueue(new TestQueueItem { Value = 300 }, 1000));
+
+            var item100 = bbq.Dequeue();
+
+            Assert.Equal(2, bbq.Size);
+            Assert.Equal(1, bbq.Count);
+            Assert.Equal(100, item100.Value);
+
+            bbq.Enqueue(new TestQueueItem { Value = 500 }, 1000);
+            Assert.Equal(2, bbq.Count);
+
+            var item200 = bbq.Dequeue();
+
+            Assert.Equal(200, item200.Value);
+            Assert.Equal(1, bbq.Count);
+
+            bbq.Enqueue(new TestQueueItem { Value = 400 });
+
+            Task.Run(() =>
+               {
+                   bbq.Enqueue(new TestQueueItem { Value = 600 });
+               });
+
+            await Task.Delay(5000);
+
+            var item500 = bbq.Dequeue();
+
+            await Task.Delay(1000);
+
+            Assert.Equal(500, item500.Value);
+            Assert.Equal(2, bbq.Count); //400 and 600 should be in here
+
+            var item400 = bbq.Dequeue();
+            Assert.Equal(1, bbq.Count);
+            Assert.Equal(400, item400.Value);
+            
+            var item600 = bbq.Dequeue();
+            Assert.Equal(0, bbq.Count);
+            Assert.Equal(600, item600.Value);
+            
+
+
+        }
+
+#pragma warning restore xUnit2013 // Do not use equality check to check for collection size.
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+        [Fact]
+        void TestingGround()
+        {
+
+        }
+    }
+}

--- a/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
+++ b/src/PBase.Test/Collections/BoundedBlockingQueueTests.cs
@@ -176,8 +176,29 @@ namespace PBase.Test.Collections
             Assert.Equal(1, bbq.Count);
             var item400 = bbq.Dequeue();
             Assert.Equal(400, item400.Value);
+            Assert.Equal(0, bbq.Count);
+
+            bool threwObjectDisposedEx = false;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    bbq.Dequeue();
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    threwObjectDisposedEx = true;
+                }
+            });
+
+            await Task.Delay(1500);
 
             bbq.Dispose();
+
+            await Task.Delay(1500);
+
+            Assert.True(threwObjectDisposedEx);
 
             Assert.True(bbq.IsDisposed);
 

--- a/src/PBase/BaseDisposable.cs
+++ b/src/PBase/BaseDisposable.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace PBase
 {

--- a/src/PBase/BaseDisposable.cs
+++ b/src/PBase/BaseDisposable.cs
@@ -32,7 +32,7 @@ namespace PBase
             {
                 Dispose(true);
             }
-            catch (Exception)
+            catch
             {
                 // Disposing so not much we can do with this exception
             }

--- a/src/PBase/Collections/BoundedBlockingQueue.cs
+++ b/src/PBase/Collections/BoundedBlockingQueue.cs
@@ -1,0 +1,317 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace PBase.Collections
+{
+    public sealed class BoundedBlockingQueue<T> : BaseDisposable, ICollection<T> where T : class
+    {
+        private readonly int m_nSize;            // Max number of elements queue can hold without blocking.
+        private T[] m_aItems;           // Buffer used to store queue objects with max "Size".
+        private int m_nCount;           // Current number of elements in the queue.
+        private int m_nHead;            // Index of slot for object to remove on next Dequeue. 
+        private int m_nTail;            // Index of slot for next Enqueue object.
+        private readonly AutoResetEvent m_evQueue;
+
+        //TODO
+        //clear
+        //dispose
+        //unit tests
+        //source code documentation
+        //comments
+        //get enumerator methods are a question mark
+        //regions
+
+        public int Count
+        {
+            get => m_nCount;
+        }
+
+        public int Size
+        {
+            get => m_nSize;
+        }
+
+        public SafeLock QueueSyncRoot
+        {
+            get => SyncRoot;
+        }
+
+        public T[] Values
+        {
+            get
+            {
+                using (SyncRoot.Enter())
+                {
+                    T[] values;
+
+                    if (IsDisposing || IsDisposed)
+                    {
+                        throw new ObjectDisposedException(nameof(BoundedBlockingQueue<T>));
+                    }
+
+                    values = new T[m_nCount];
+                    int nPos = m_nHead;
+
+                    for (int i = 0; i < m_nCount; i++)
+                    {
+                        values[i] = m_aItems[nPos++];
+                        nPos %= m_nSize;
+                    }
+
+                    return values;
+                }
+            }
+        }
+
+        public bool IsReadOnly => false;
+
+        public BoundedBlockingQueue(int size)
+        {
+            if (size < 1)
+            {
+                throw new ArgumentOutOfRangeException("size", "size must be greater than zero.");
+            }
+
+            m_nSize = size;
+            m_aItems = new T[m_nSize];
+
+            m_nCount = 0;
+            m_nHead = 0;
+            m_nTail = 0;
+            m_evQueue = new AutoResetEvent(false);
+        }
+
+        //blocking 
+        //if timeout > timeout.inf
+        //will timeout either waiting for sync root or waiting for space in queue to
+        //become available
+        //will throw if timeout on waiting for sync root
+        public bool Enqueue(T item, int timeoutMilliseconds = -1)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException("item", "item cannot be null");
+            }
+
+            if (IsDisposing || IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(BoundedBlockingQueue<T>));
+            }
+
+            while (m_nCount == m_nSize)
+            {
+                if (!m_evQueue.WaitOne(timeoutMilliseconds))
+                {
+                    throw new TimeoutException("Enqueue timed out while waiting for available queue space");
+                }
+
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(BoundedBlockingQueue<T>));
+                }
+            }
+
+            using (SyncRoot.Enter(timeoutMilliseconds))
+            {
+                m_aItems[m_nTail++] = item;
+                m_nTail %= m_nSize;
+                m_nCount++;
+
+                m_evQueue.Set();
+
+                return true;
+            }
+        }
+
+        public void Add(T item)
+        {
+            Enqueue(item);
+        }
+
+        public bool TryEnqueue(T item)
+        {
+            using (SyncRoot.Enter(timeoutMilliseconds: 0))
+            {
+                if (item == null)
+                {
+                    return false;
+                }
+
+                if (IsDisposing || IsDisposed)
+                {
+                    return false;
+                }
+
+                if (m_nCount == m_nSize)
+                {
+                    return false;
+                }
+
+                m_aItems[m_nTail++] = item;
+                m_nTail %= m_nSize;
+                m_nCount++;
+
+                m_evQueue.Set();
+
+                return true;
+            }
+        }
+
+        public T Peek()
+        {
+            using (SyncRoot.Enter())
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(BoundedBlockingQueue<T>));
+                }
+
+                if (m_nCount == 0)
+                {
+                    throw new InvalidOperationException("Bounded Blocking Queue is empty");
+                }
+
+                T value = m_aItems[m_nHead];
+                return value;
+            }
+        }
+
+        public bool TryPeek(out T item)
+        {
+            using (SyncRoot.Enter())
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    item = null;
+                    return false;
+                }
+
+                if (m_nCount == 0)
+                {
+                    item = null;
+                    return false;
+                }
+
+                item = m_aItems[m_nHead];
+                return true;
+            }
+        }
+
+        public T Dequeue(int timeoutMilliseconds = -1)
+        {
+            if (IsDisposing || IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(BoundedBlockingQueue<T>));
+            }
+
+            while (m_nCount == 0)
+            {
+                if (!m_evQueue.WaitOne(timeoutMilliseconds))
+                {
+                    throw new TimeoutException("Dequeue timed out while waiting for queue item to dequeue");
+                }
+
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(BoundedBlockingQueue<T>));
+                }
+            }
+
+            using (SyncRoot.Enter(timeoutMilliseconds))
+            {
+                T value = m_aItems[m_nHead];
+                m_aItems[m_nHead++] = null;
+                m_nHead %= m_nSize;
+                m_nCount--;
+
+                m_evQueue.Set();
+
+                return value;
+            }
+        }
+
+        public bool TryDequeue(out T item)
+        {
+            using (SyncRoot.Enter(timeoutMilliseconds: 0))
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    item = null;
+                    return false;
+                }
+
+                if (m_nCount == 0)
+                {
+                    item = null;
+                    return false;
+                }
+
+                item = m_aItems[m_nHead];
+                m_aItems[m_nHead++] = null;
+                m_nHead %= m_nSize;
+                m_nCount--;
+
+                m_evQueue.Set();
+
+                return true;
+            }
+        }
+
+        //will only throw if item is not the tail
+        // otherise, just return dequeue
+        public bool Remove(T item)
+        {
+            using (SyncRoot.Enter())
+            {
+                if (m_aItems[m_nHead] == item)
+                {
+                    return TryDequeue(out item);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            //using (SyncRoot.Enter())
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(T item)
+        {
+            return Values.Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            T[] tmpArray = Values;
+            tmpArray.CopyTo(array, arrayIndex);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            //using (SyncRoot.Enter())
+            //close evt handle
+            throw new NotImplementedException();
+        }
+
+        //we could have enumerator on the values array?
+        public IEnumerator<T> GetEnumerator()
+        {
+            return (IEnumerator<T>)Values.GetEnumerator();
+            //throw new NotImplementedException("No Enumerator on Bounded Blocking Queue");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return Values.GetEnumerator();
+            //throw new NotImplementedException("No Enumerator on Bounded Blocking Queue");
+        }
+    }
+}

--- a/src/PBase/Collections/BoundedBlockingQueue.cs
+++ b/src/PBase/Collections/BoundedBlockingQueue.cs
@@ -174,14 +174,14 @@ namespace PBase.Collections
 
         public bool TryEnqueue(T item, int timeoutMilliseconds = 0)
         {
+            if (item == null)
+            {
+                return false;
+            }
+
             //The method only throws exception on thread lock timeout
             using (IWaitable syncLock = SyncRoot.Enter(timeoutMilliseconds) as IWaitable)
             {
-                if (item == null)
-                {
-                    return false;
-                }
-
                 if (IsDisposing || IsDisposed)
                 {
                     return false;
@@ -214,7 +214,7 @@ namespace PBase.Collections
                 {
                     throw new ObjectDisposedException(nameof(BoundedBlockingQueue<T>));
                 }
-                
+
                 if (m_count == 0)
                 {
                     if (waitForEnqueue)

--- a/src/PBase/Collections/BoundedBlockingQueue.cs
+++ b/src/PBase/Collections/BoundedBlockingQueue.cs
@@ -9,7 +9,6 @@ namespace PBase.Collections
     {
         //Possible additions
         // - Using cancellation tokens
-        // - CompleteEnqueuing method
         // - Different timeout parameters for entering thread lock and waiting for free space to enqueue
         //      item to peek or dequeue
 

--- a/src/PBase/SafeLock.cs
+++ b/src/PBase/SafeLock.cs
@@ -85,6 +85,9 @@ namespace PBase
             return Enter((int)sm_timeout.TotalMilliseconds);
         }
         
+        //Wait and PulseAll methods are private
+        //so only called from SafeLockDisposer class created when entering lock
+        //This ensures these methods are properly used inside a lock
         private bool Wait(int timeoutMilliseconds)
         {
             if (Monitor.Wait(m_synchronised, timeoutMilliseconds))

--- a/src/PBase/SafeLock.cs
+++ b/src/PBase/SafeLock.cs
@@ -90,13 +90,6 @@ namespace PBase
             return Enter(sm_timeout.Milliseconds);
         }
 
-        /*public bool Wait(int timeoutMilliseconds = -1)
-        {
-
-
-            //return Monitor.Wait(m_synchronised, timeoutMilliseconds);
-        }*/
-
         public void Exit()
         {
             if (m_thread != Thread.CurrentThread)


### PR DESCRIPTION
BoundedBlockingQueue is a thread safe queue with a given set maximum number of items that blocks dequeuing on empty queue and enqueuing on full queue. Timeouts can be used to set a timeout on how long to block and how long to wait for lock. Try methods can be used that will only through exceptions on thread lock timeout. Unit test coverage on BoundedBlockingQueue is currently at 95%

Made changes to SafeLock to create BoundedBlockingQueue - thread reference counting removed and added Wait and PulseAll methods. Also added overloaded methods with timeout parameters. Accompanying unit test changes made.

Possible additions: 
         - Using cancellation tokens
         - Different timeout parameters for entering thread lock and waiting for free space to enqueue
              item to peek or dequeue