### PR TITLE
Primitive Object Pool

### DIFF
--- a/src/PBase.Test/Collections/PrimitiveObjectPoolTests.cs
+++ b/src/PBase.Test/Collections/PrimitiveObjectPoolTests.cs
@@ -1,7 +1,7 @@
-﻿using PBase.Test.Support;
+﻿using PBase.Collections;
+using PBase.Test.Support;
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,13 +10,443 @@ namespace PBase.Test.Collections
     public class PrimitiveObjectPoolTests : BaseUnitTest
     {
         public PrimitiveObjectPoolTests(ITestOutputHelper testOutputHelper)
-            : base(testOutputHelper) {}
+            : base(testOutputHelper) { }
+
+        private class TestObjectPoolItem
+        {
+            public TestObjectPoolItem() { }
+        }
 
         [Fact]
-        void TestingGounds()
+        void TestPrimitiveObjectPoolsCreation()
         {
-            //need to check that in use counter is always correct
+            PrimitiveObjectPool<TestObjectPoolItem> primPool = null;
+            ResizablePrimitiveObjectPool<TestObjectPoolItem> resizePool = null;
+            BlockingPrimitiveObjectPool<TestObjectPoolItem> blockPool = null;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                primPool = new PrimitiveObjectPool<TestObjectPoolItem>(0);
+            });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                resizePool = new ResizablePrimitiveObjectPool<TestObjectPoolItem>(0);
+            });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                blockPool = new BlockingPrimitiveObjectPool<TestObjectPoolItem>(0);
+            });
+
+            Assert.Null(primPool);
+            Assert.Null(resizePool);
+            Assert.Null(blockPool);
+
+            primPool = new PrimitiveObjectPool<TestObjectPoolItem>(1);
+            resizePool = new ResizablePrimitiveObjectPool<TestObjectPoolItem>(1);
+            blockPool = new BlockingPrimitiveObjectPool<TestObjectPoolItem>(1);
+
+            Assert.NotNull(primPool);
+            Assert.NotNull(resizePool);
+            Assert.NotNull(blockPool);
         }
+
+        [Fact]
+        void TestPrimitiveObjectPoolsDispose()
+        {
+            PrimitiveObjectPool<TestObjectPoolItem> primPool = new PrimitiveObjectPool<TestObjectPoolItem>(1);
+            ResizablePrimitiveObjectPool<TestObjectPoolItem> resizePool = new ResizablePrimitiveObjectPool<TestObjectPoolItem>(1);
+            BlockingPrimitiveObjectPool<TestObjectPoolItem> blockPool = new BlockingPrimitiveObjectPool<TestObjectPoolItem>(1);
+
+            primPool.Dispose();
+            resizePool.Dispose();
+            blockPool.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => primPool.InUse);
+            Assert.Throws<ObjectDisposedException>(() => primPool.PoolCount);
+            Assert.Throws<ObjectDisposedException>(() => primPool.Size);
+            Assert.Throws<ObjectDisposedException>(() => primPool.TryObtain(out var item));
+            Assert.Throws<ObjectDisposedException>(() => primPool.TryRelease(new TestObjectPoolItem()));
+            Assert.Throws<ObjectDisposedException>(() => primPool.Obtain());
+            Assert.Throws<ObjectDisposedException>(() => primPool.Release(new TestObjectPoolItem()));
+
+            Assert.Throws<ObjectDisposedException>(() => resizePool.InUse);
+            Assert.Throws<ObjectDisposedException>(() => resizePool.PoolCount);
+            Assert.Throws<ObjectDisposedException>(() => resizePool.Size);
+            Assert.Throws<ObjectDisposedException>(() => resizePool.TryObtain(out var item));
+            Assert.Throws<ObjectDisposedException>(() => resizePool.TryRelease(new TestObjectPoolItem()));
+            Assert.Throws<ObjectDisposedException>(() => resizePool.Obtain());
+            Assert.Throws<ObjectDisposedException>(() => resizePool.Release(new TestObjectPoolItem()));
+
+            Assert.Throws<ObjectDisposedException>(() => blockPool.InUse);
+            Assert.Throws<ObjectDisposedException>(() => blockPool.PoolCount);
+            Assert.Throws<ObjectDisposedException>(() => blockPool.Size);
+            Assert.Throws<ObjectDisposedException>(() => blockPool.TryObtain(out var item));
+            Assert.Throws<ObjectDisposedException>(() => blockPool.TryRelease(new TestObjectPoolItem()));
+            Assert.Throws<ObjectDisposedException>(() => blockPool.Obtain());
+            Assert.Throws<ObjectDisposedException>(() => blockPool.Release(new TestObjectPoolItem()));
+        }
+
+        [Fact]
+        void TestPrimitiveObjectPoolObtainRelease()
+        {
+            PrimitiveObjectPool<TestObjectPoolItem> primPool = new PrimitiveObjectPool<TestObjectPoolItem>(3);
+
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(0, primPool.InUse);
+            Assert.Equal(3, primPool.PoolCount);
+
+            TestObjectPoolItem test = new TestObjectPoolItem();
+
+            Assert.False(primPool.TryRelease(test));
+
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(0, primPool.InUse);
+            Assert.Equal(3, primPool.PoolCount);
+
+            Assert.Throws<InvalidOperationException>(() => primPool.Release(test));
+
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(0, primPool.InUse);
+            Assert.Equal(3, primPool.PoolCount);
+
+            TestObjectPoolItem test1;
+            TestObjectPoolItem test2;
+            TestObjectPoolItem test3;
+            TestObjectPoolItem test4;
+
+            Assert.True(primPool.TryObtain(out test1));
+
+            Assert.NotNull(test1);
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(1, primPool.InUse);
+            Assert.Equal(2, primPool.PoolCount);
+
+            test2 = primPool.Obtain();
+
+            Assert.NotNull(test2);
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(2, primPool.InUse);
+            Assert.Equal(1, primPool.PoolCount);
+
+            test3 = primPool.Obtain();
+
+            Assert.NotNull(test3);
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(3, primPool.InUse);
+            Assert.Equal(0, primPool.PoolCount);
+
+            Assert.False(primPool.TryObtain(out test4));
+
+            Assert.Null(test4);
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(3, primPool.InUse);
+            Assert.Equal(0, primPool.PoolCount);
+
+            Assert.Throws<InvalidOperationException>(() => test4 = primPool.Obtain());
+
+            Assert.Null(test4);
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(3, primPool.InUse);
+            Assert.Equal(0, primPool.PoolCount);
+
+            Assert.True(primPool.TryRelease(test1));
+
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(2, primPool.InUse);
+            Assert.Equal(1, primPool.PoolCount);
+
+            primPool.Release(test1);
+
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(1, primPool.InUse);
+            Assert.Equal(2, primPool.PoolCount);
+
+            primPool.Release(test1);
+
+            Assert.Equal(3, primPool.Size);
+            Assert.Equal(0, primPool.InUse);
+            Assert.Equal(3, primPool.PoolCount);
+        }
+
+        [Fact]
+        void TestResizablePrimitiveObjectPoolObtainRelease()
+        {
+            ResizablePrimitiveObjectPool<TestObjectPoolItem> resizePool = new ResizablePrimitiveObjectPool<TestObjectPoolItem>(3);
+
+            Assert.Equal(3, resizePool.Size);
+            Assert.Equal(0, resizePool.InUse);
+            Assert.Equal(3, resizePool.PoolCount);
+
+            TestObjectPoolItem test = new TestObjectPoolItem();
+
+            Assert.False(resizePool.TryRelease(test));
+
+            Assert.Equal(3, resizePool.Size);
+            Assert.Equal(0, resizePool.InUse);
+            Assert.Equal(3, resizePool.PoolCount);
+
+            resizePool.Release(test);
+
+            Assert.Equal(4, resizePool.Size);
+            Assert.Equal(0, resizePool.InUse);
+            Assert.Equal(4, resizePool.PoolCount);
+
+            TestObjectPoolItem test1;
+            TestObjectPoolItem test2;
+            TestObjectPoolItem test3;
+            TestObjectPoolItem test4;
+            TestObjectPoolItem test5;
+
+            Assert.True(resizePool.TryObtain(out test1));
+
+            Assert.NotNull(test1);
+            Assert.Equal(4, resizePool.Size);
+            Assert.Equal(1, resizePool.InUse);
+            Assert.Equal(3, resizePool.PoolCount);
+
+            test2 = resizePool.Obtain();
+
+            Assert.NotNull(test2);
+            Assert.Equal(4, resizePool.Size);
+            Assert.Equal(2, resizePool.InUse);
+            Assert.Equal(2, resizePool.PoolCount);
+
+            test3 = resizePool.Obtain();
+
+            Assert.NotNull(test3);
+            Assert.Equal(4, resizePool.Size);
+            Assert.Equal(3, resizePool.InUse);
+            Assert.Equal(1, resizePool.PoolCount);
+
+            test4 = resizePool.Obtain();
+
+            Assert.NotNull(test4);
+            Assert.Equal(4, resizePool.Size);
+            Assert.Equal(4, resizePool.InUse);
+            Assert.Equal(0, resizePool.PoolCount);
+
+            Assert.False(resizePool.TryObtain(out test5));
+
+            Assert.Null(test5);
+            Assert.Equal(4, resizePool.Size);
+            Assert.Equal(4, resizePool.InUse);
+            Assert.Equal(0, resizePool.PoolCount);
+
+            test5 = resizePool.Obtain();
+
+            Assert.NotNull(test5);
+            Assert.Equal(5, resizePool.Size);
+            Assert.Equal(5, resizePool.InUse);
+            Assert.Equal(0, resizePool.PoolCount);
+
+            Assert.True(resizePool.TryRelease(test5));
+
+            Assert.Equal(5, resizePool.Size);
+            Assert.Equal(4, resizePool.InUse);
+            Assert.Equal(1, resizePool.PoolCount);
+
+            resizePool.Release(test5);
+
+            Assert.Equal(5, resizePool.Size);
+            Assert.Equal(3, resizePool.InUse);
+            Assert.Equal(2, resizePool.PoolCount);
+
+            resizePool.Release(test5);
+
+            Assert.Equal(5, resizePool.Size);
+            Assert.Equal(2, resizePool.InUse);
+            Assert.Equal(3, resizePool.PoolCount);
+
+            resizePool.Release(test5);
+
+            Assert.Equal(5, resizePool.Size);
+            Assert.Equal(1, resizePool.InUse);
+            Assert.Equal(4, resizePool.PoolCount);
+
+            resizePool.Release(test5);
+
+            Assert.Equal(5, resizePool.Size);
+            Assert.Equal(0, resizePool.InUse);
+            Assert.Equal(5, resizePool.PoolCount);
+
+            resizePool.Release(test5);
+
+            Assert.Equal(6, resizePool.Size);
+            Assert.Equal(0, resizePool.InUse);
+            Assert.Equal(6, resizePool.PoolCount);
+        }
+
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+        [Fact]
+        async void TestBlockingPrimitiveObjectPoolObtainRelease()
+        {
+            BlockingPrimitiveObjectPool<TestObjectPoolItem> blockPool = new BlockingPrimitiveObjectPool<TestObjectPoolItem>(3);
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(0, blockPool.InUse);
+            Assert.Equal(3, blockPool.PoolCount);
+
+            TestObjectPoolItem test = new TestObjectPoolItem();
+
+            Assert.False(blockPool.TryRelease(test));
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(0, blockPool.InUse);
+            Assert.Equal(3, blockPool.PoolCount);
+
+            Task.Run(() =>
+            {
+                blockPool.Release(test);
+            });
+
+            await Task.Delay(500);
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(0, blockPool.InUse);
+            Assert.Equal(3, blockPool.PoolCount);
+
+            var newTest = blockPool.Obtain();
+
+            await Task.Delay(500);
+
+            Assert.NotNull(newTest);
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(0, blockPool.InUse);
+            Assert.Equal(3, blockPool.PoolCount);
+
+            TestObjectPoolItem test1;
+            TestObjectPoolItem test2;
+            TestObjectPoolItem test3;
+            TestObjectPoolItem test4;
+            TestObjectPoolItem test5 = null;
+
+            Assert.True(blockPool.TryObtain(out test1));
+
+            Assert.NotNull(test1);
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(1, blockPool.InUse);
+            Assert.Equal(2, blockPool.PoolCount);
+
+            test2 = blockPool.Obtain();
+
+            Assert.NotNull(test2);
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(2, blockPool.InUse);
+            Assert.Equal(1, blockPool.PoolCount);
+
+            test3 = blockPool.Obtain();
+
+            Assert.NotNull(test3);
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(3, blockPool.InUse);
+            Assert.Equal(0, blockPool.PoolCount);
+
+            Assert.False(blockPool.TryObtain(out test4));
+
+            Assert.Null(test4);
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(3, blockPool.InUse);
+            Assert.Equal(0, blockPool.PoolCount);
+
+            Task.Run(() =>
+            {
+                test4 = blockPool.Obtain();
+            });
+
+            Task.Run(() =>
+            {
+                test5 = blockPool.Obtain();
+            });
+
+            await Task.Delay(500);
+
+            Assert.Null(test4);
+            Assert.Null(test5);
+
+            blockPool.Release(test1);
+
+            await Task.Delay(500);
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(3, blockPool.InUse);
+            Assert.Equal(0, blockPool.PoolCount);
+
+            Assert.True((test4 != null) ^ (test5 != null));
+
+            blockPool.Release(test1);
+
+            await Task.Delay(1000);
+
+            Assert.NotNull(test4);
+            Assert.NotNull(test5);
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(3, blockPool.InUse);
+            Assert.Equal(0, blockPool.PoolCount);
+
+            Assert.True(blockPool.TryRelease(test1));
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(2, blockPool.InUse);
+            Assert.Equal(1, blockPool.PoolCount);
+
+            blockPool.Release(test1);
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(1, blockPool.InUse);
+            Assert.Equal(2, blockPool.PoolCount);
+
+            blockPool.Release(test1);
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(0, blockPool.InUse);
+            Assert.Equal(3, blockPool.PoolCount);
+
+            bool dispose1 = false;
+            bool dispose2 = false;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    blockPool.Release(test1);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    dispose1 = true;
+                }
+            });
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    blockPool.Release(test2);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    dispose2 = true;
+                }
+            });
+
+            await Task.Delay(500);
+
+            Assert.Equal(3, blockPool.Size);
+            Assert.Equal(0, blockPool.InUse);
+            Assert.Equal(3, blockPool.PoolCount);
+
+            blockPool.Dispose();
+
+            await Task.Delay(500);
+
+            Assert.True(dispose1);
+            Assert.True(dispose2);
+        }
+
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
     }
 }

--- a/src/PBase.Test/Collections/PrimitiveObjectPoolTests.cs
+++ b/src/PBase.Test/Collections/PrimitiveObjectPoolTests.cs
@@ -1,0 +1,22 @@
+﻿using PBase.Test.Support;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PBase.Test.Collections
+{
+    public class PrimitiveObjectPoolTests : BaseUnitTest
+    {
+        public PrimitiveObjectPoolTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper) {}
+
+        [Fact]
+        void TestingGounds()
+        {
+            //need to check that in use counter is always correct
+        }
+
+    }
+}

--- a/src/PBase.Test/PBase.Test.csproj
+++ b/src/PBase.Test/PBase.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/PBase/Collections/BlockingPrimitiveObjectPool.cs
+++ b/src/PBase/Collections/BlockingPrimitiveObjectPool.cs
@@ -3,6 +3,10 @@ using System.Threading;
 
 namespace PBase.Collections
 {
+    /// <summary>
+    /// <c>BlockingPrimitiveObjectPool</c> blocks when obtaining on empty pool and releasing on full pool
+    /// </summary>
+    /// <typeparam name="T"><c>T</c> must be a class with a parameterless constructor</typeparam>
     public class BlockingPrimitiveObjectPool<T> : PrimitiveObjectPool<T> where T : class, new()
     {
         #region Private Fields
@@ -11,6 +15,11 @@ namespace PBase.Collections
         #endregion
 
         #region Constructor
+        /// <summary>
+        /// Create a <c>BlockingPrimitiveObjectPool</c> that blocks instead of throwing an <c>ArgumentOutOfRangeException</c>
+        /// </summary>
+        /// <param name="size">the number of objects this object pool will hold</param>
+        /// <exception cref="ArgumentOutOfRangeException">throws if <c>size</c> parameter is less than 1</exception>
         public BlockingPrimitiveObjectPool(int size) : base(size)
         {
             m_event = new ManualResetEvent(false);
@@ -30,6 +39,11 @@ namespace PBase.Collections
         #endregion
 
         #region Overridden Obtain and Release methods
+        /// <summary>
+        /// <c>Obtain</c> and remove an object from the pool - blocks thread until an object can be obtained
+        /// </summary>
+        /// <returns>returns an object of type <typeparamref name="T"/> from the pool</returns>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public override T Obtain()
         {
             T item;
@@ -50,6 +64,11 @@ namespace PBase.Collections
             return item;
         }
 
+        /// <summary>
+        /// <c>Release</c> an object and add it back into the pool - blocks thread until the object can be released back into the pool
+        /// </summary>
+        /// <param name="item">the object released back into the pool</param>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public override void Release(T item)
         {
             //Multiple threads could be waiting for successful Obtain

--- a/src/PBase/Collections/BlockingPrimitiveObjectPool.cs
+++ b/src/PBase/Collections/BlockingPrimitiveObjectPool.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace PBase.Collections
+{
+    public class BlockingPrimitiveObjectPool<T> : PrimitiveObjectPool<T> where T : class, new()
+    {
+        private AutoResetEvent m_event;
+
+        public BlockingPrimitiveObjectPool(int size) : base(size)
+        {
+            m_event = new AutoResetEvent(false);
+        }
+        
+        public override T Obtain()
+        {
+            T item;
+
+            while (!TryObtain(out item))
+            {
+                m_event.WaitOne();
+            }
+
+            m_event.Set();
+            return item;
+        }
+
+        public override void Release(T item)
+        {
+            while (!TryRelease(item))
+            {
+                m_event.WaitOne();
+            }
+
+            m_event.Set();
+        }
+    }
+}

--- a/src/PBase/Collections/BlockingPrimitiveObjectPool.cs
+++ b/src/PBase/Collections/BlockingPrimitiveObjectPool.cs
@@ -1,39 +1,73 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace PBase.Collections
 {
     public class BlockingPrimitiveObjectPool<T> : PrimitiveObjectPool<T> where T : class, new()
     {
-        private AutoResetEvent m_event;
+        #region Private Fields
+        private ManualResetEvent m_event;               // Used to block and signal threads instead of throwing exceptions
+        private volatile bool m_isCancelled = false;    // Used to make sure threads will unblock when disposing
+        #endregion
 
+        #region Constructor
         public BlockingPrimitiveObjectPool(int size) : base(size)
         {
-            m_event = new AutoResetEvent(false);
+            m_event = new ManualResetEvent(false);
         }
-        
+        #endregion
+
+        #region Methods
+
+        #region Overridden Dispose method
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            m_isCancelled = true;   //Make sure threads don't get caught in while loops
+            m_event.Set();          //Unblock all waiting threads
+            m_event.Close();
+        }
+        #endregion
+
+        #region Overridden Obtain and Release methods
         public override T Obtain()
         {
             T item;
 
-            while (!TryObtain(out item))
+            //Multiple threads could be waiting for successful Release
+            while (!TryObtain(out item) && !m_isCancelled)
             {
-                m_event.WaitOne();
+                m_event.Reset();    //Reset so that thread doesn't just fall through WaitOne
+                m_event.WaitOne();  //Wait until successful Release
             }
 
-            m_event.Set();
+            if (IsDisposing || IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+            }
+
+            m_event.Set();  //Signal that there is at least one item to obtain from pool
             return item;
         }
 
         public override void Release(T item)
         {
-            while (!TryRelease(item))
+            //Multiple threads could be waiting for successful Obtain
+            while (!TryRelease(item) && !m_isCancelled)
             {
-                m_event.WaitOne();
+                m_event.Reset();    //Reset so that thread doesn't just fall through WaitOne
+                m_event.WaitOne();  //Wait until successful Obtain
             }
 
-            m_event.Set();
+            if (IsDisposing || IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+            }
+
+            m_event.Set();  //Signal that there is at least one available space to release back into pool
         }
+        #endregion
+
+        #endregion
     }
 }

--- a/src/PBase/Collections/PrimitiveObjectPool.cs
+++ b/src/PBase/Collections/PrimitiveObjectPool.cs
@@ -5,14 +5,55 @@ namespace PBase.Collections
 {
     public class PrimitiveObjectPool<T> : BaseDisposable where T : class, new()
     {
-        public int Size { get; protected set; }
+        #region Private/Protected Fields
+        private int m_size;                             // Current size of object pool - should always equal bag count + in use count
+        private int m_inUse;                            // Number of objects currently in use (i.e., not in pool)    
+        protected ConcurrentBag<T> m_internalStorage;   // Storing objects not in use
+        #endregion
 
-        private int m_inUse;
-        public int InUse
+        #region Public Properties
+        public int Size
         {
-            get => m_inUse;
+            get
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                }
+
+                return m_size;
+            }
+
             protected set
             {
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                }
+
+                m_size = value;
+            }
+        }
+
+        public int InUse
+        {
+            get
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                }
+
+                return m_inUse;
+            }
+
+            protected set
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                }
+
                 if (value < 0)
                 {
                     throw new Exception("Number of in use objects is negative");
@@ -22,8 +63,21 @@ namespace PBase.Collections
             }
         }
 
-        protected ConcurrentBag<T> m_internalStorage; //Storing objects not in use
+        public int PoolCount
+        {
+            get
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                }
 
+                return m_internalStorage.Count;
+            }
+        }
+        #endregion
+
+        #region Constructor
         public PrimitiveObjectPool(int size)
         {
             if (size < 1)
@@ -35,27 +89,33 @@ namespace PBase.Collections
 
             for (int i = 0; i < size; i++)
             {
+                //Instantiate with default constructor
                 m_internalStorage.Add(new T());
             }
 
             Size = size;
         }
+        #endregion
 
+        #region Methods
+
+        #region Dispose Method
         protected override void Dispose(bool disposing)
         {
-            Size = 0;
-            InUse = 0;
+            m_size = 0;
+            m_inUse = 0;
             m_internalStorage = null;
-            //need to add checks of isdisposing || isdisposed
         }
+        #endregion
 
+        #region Obtain Methods
         public virtual T Obtain()
         {
             if (TryObtain(out T item))
             {
                 return item;
             }
-            else
+            else //Default implementation when obtaining on empty pool - throw exception
             {
                 throw new InvalidOperationException("No more objects to obtain");
             }
@@ -63,19 +123,31 @@ namespace PBase.Collections
 
         public bool TryObtain(out T item)
         {
-            if (m_internalStorage.TryTake(out item))
+            using (SyncRoot.Enter())
             {
-                InUse++;
-                return true;
-            }
-            else
-            {
-                return false;
+                //This is called from Obtain so only need to check dispose state here
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                }
+
+                if (m_internalStorage.TryTake(out item)) //This will decrement count
+                {
+                    InUse++;
+                    return true;
+                }
+                else //if bag is empty
+                {
+                    return false;
+                }
             }
         }
+        #endregion
 
+        #region Release Methods
         public virtual void Release(T item)
         {
+            //Default implementation when releasing on full pool - throw exception
             if (!TryRelease(item))
             {
                 throw new InvalidOperationException("Object pool is full");
@@ -84,20 +156,29 @@ namespace PBase.Collections
 
         public bool TryRelease(T item)
         {
-            if (m_internalStorage.Count == Size)
+            using (SyncRoot.Enter())
             {
-                return false;
-            }
-            else
-            {
-                m_internalStorage.Add(item);
-                InUse--;
-                return true;
+                //This is called from Obtain so only need to check dispose state here
+                if (IsDisposing || IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                }
+
+                //If storage bag is full i.e., equal to initial size, don't release item into bag
+                if (m_internalStorage.Count == Size)
+                {
+                    return false;
+                }
+                else
+                {
+                    m_internalStorage.Add(item); //This will increment storage bag count
+                    InUse--;
+                    return true;
+                }
             }
         }
-        
-        //resizable pool - obtain method automatically increases in size
-        //blocking pool - blocks until succ release
-        //default (implemented here) just throws if no objects to obtain from bag
+        #endregion
+
+        #endregion
     }
 }

--- a/src/PBase/Collections/PrimitiveObjectPool.cs
+++ b/src/PBase/Collections/PrimitiveObjectPool.cs
@@ -3,6 +3,10 @@ using System.Collections.Concurrent;
 
 namespace PBase.Collections
 {
+    /// <summary>
+    /// Default implementation of <c>PrimitiveObjectPool</c>
+    /// </summary>
+    /// <typeparam name="T"><c>T</c> must be a class with a parameterless constructor</typeparam>
     public class PrimitiveObjectPool<T> : BaseDisposable where T : class, new()
     {
         #region Private/Protected Fields
@@ -12,6 +16,10 @@ namespace PBase.Collections
         #endregion
 
         #region Public Properties
+        /// <summary>
+        /// Total size of the object pool - equal to InUse + PoolCount
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public int Size
         {
             get
@@ -35,6 +43,11 @@ namespace PBase.Collections
             }
         }
 
+        /// <summary>
+        /// Number of objects currently used by the application
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
+        /// <exception cref="Exception">throws if set to less than 0</exception>
         public int InUse
         {
             get
@@ -63,6 +76,10 @@ namespace PBase.Collections
             }
         }
 
+        /// <summary>
+        /// Number of objects still in the object pool
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public int PoolCount
         {
             get
@@ -78,6 +95,11 @@ namespace PBase.Collections
         #endregion
 
         #region Constructor
+        /// <summary>
+        /// Create a default <c>PrimitiveObjectPool</c> which holds a number of objects
+        /// </summary>
+        /// <param name="size">the number of objects this object pool will hold</param>
+        /// <exception cref="ArgumentOutOfRangeException">throws if <c>size</c> parameter is less than 1</exception>
         public PrimitiveObjectPool(int size)
         {
             if (size < 1)
@@ -109,6 +131,11 @@ namespace PBase.Collections
         #endregion
 
         #region Obtain Methods
+        /// <summary>
+        /// <c>Obtain</c> and remove an object from the pool
+        /// </summary>
+        /// <returns>returns an object of type <typeparamref name="T"/> from the pool</returns>
+        /// <exception cref="InvalidOperationException">throws if there are no more objects in the pool to be obtained</exception>
         public virtual T Obtain()
         {
             if (TryObtain(out T item))
@@ -121,6 +148,12 @@ namespace PBase.Collections
             }
         }
 
+        /// <summary>
+        /// <c>TryObtain</c> an object and remove it from the pool - does not throw an exception if pool is empty
+        /// </summary>
+        /// <param name="item">the object obtained from the pool, if successful - null if unsuccessful</param>
+        /// <returns>returns true if successful, false if unsuccessful i.e. pool is empty</returns>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public bool TryObtain(out T item)
         {
             using (SyncRoot.Enter())
@@ -145,6 +178,11 @@ namespace PBase.Collections
         #endregion
 
         #region Release Methods
+        /// <summary>
+        /// <c>Release</c> an object and add it back into the pool
+        /// </summary>
+        /// <param name="item">the object released back into the pool</param>
+        /// <exception cref="InvalidOperationException">throws if the pool is full</exception>
         public virtual void Release(T item)
         {
             //Default implementation when releasing on full pool - throw exception
@@ -154,6 +192,12 @@ namespace PBase.Collections
             }
         }
 
+        /// <summary>
+        /// <c>TryRelease</c> an object and add it back into the pool - does not throw exception if pool is full
+        /// </summary>
+        /// <param name="item">the object released back into the pool</param>
+        /// <returns>returns true if successful, false if successful i.e. if pool is full</returns>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public bool TryRelease(T item)
         {
             using (SyncRoot.Enter())

--- a/src/PBase/Collections/PrimitiveObjectPool.cs
+++ b/src/PBase/Collections/PrimitiveObjectPool.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace PBase.Collections
+{
+    public class PrimitiveObjectPool<T> : BaseDisposable where T : class, new()
+    {
+        public int Size { get; protected set; }
+
+        private int m_inUse;
+        public int InUse
+        {
+            get => m_inUse;
+            protected set
+            {
+                if (value < 0)
+                {
+                    throw new Exception("Number of in use objects is negative");
+                }
+
+                m_inUse = value;
+            }
+        }
+
+        protected ConcurrentBag<T> m_internalStorage; //Storing objects not in use
+
+        public PrimitiveObjectPool(int size)
+        {
+            if (size < 1)
+            {
+                throw new ArgumentOutOfRangeException("size", "size must be greater than one");
+            }
+
+            m_internalStorage = new ConcurrentBag<T>();
+
+            for (int i = 0; i < size; i++)
+            {
+                m_internalStorage.Add(new T());
+            }
+
+            Size = size;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Size = 0;
+            InUse = 0;
+            m_internalStorage = null;
+            //need to add checks of isdisposing || isdisposed
+        }
+
+        public virtual T Obtain()
+        {
+            if (TryObtain(out T item))
+            {
+                return item;
+            }
+            else
+            {
+                throw new InvalidOperationException("No more objects to obtain");
+            }
+        }
+
+        public bool TryObtain(out T item)
+        {
+            if (m_internalStorage.TryTake(out item))
+            {
+                InUse++;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public virtual void Release(T item)
+        {
+            if (!TryRelease(item))
+            {
+                throw new InvalidOperationException("Object pool is full");
+            }
+        }
+
+        public bool TryRelease(T item)
+        {
+            if (m_internalStorage.Count == Size)
+            {
+                return false;
+            }
+            else
+            {
+                m_internalStorage.Add(item);
+                InUse--;
+                return true;
+            }
+        }
+        
+        //resizable pool - obtain method automatically increases in size
+        //blocking pool - blocks until succ release
+        //default (implemented here) just throws if no objects to obtain from bag
+    }
+}

--- a/src/PBase/Collections/ResizablePrimitiveObjectPool.cs
+++ b/src/PBase/Collections/ResizablePrimitiveObjectPool.cs
@@ -5,29 +5,49 @@ namespace PBase.Collections
 {
     public class ResizablePrimitiveObjectPool<T> : PrimitiveObjectPool<T> where T : class, new()
     {
+        #region Constructor
         public ResizablePrimitiveObjectPool(int size) : base(size) {}
-        
+        #endregion
+
+        #region Overridden Obtain and Release methods
         public override T Obtain()
         {
             if (TryObtain(out T item))
             {
                 return item;
             }
-            else
+            else //If the pool is empty
             {
-                InUse++;
-                Size++;
-                return new T();
+                using (SyncRoot.Enter())
+                {
+                    if (IsDisposing || IsDisposed)
+                    {
+                        throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                    }
+
+                    InUse++;
+                    Size++;         //Increment Size so releasing item will just add to pool in TryRelease
+                    return new T(); //Create new item
+                }
             }
         }
 
         public override void Release(T item)
         {
-            if (!TryRelease(item)) //if pool is full
+            if (!TryRelease(item)) //Tf the pool is full
             {
-                m_internalStorage.Add(item);
-                Size++;
+                using (SyncRoot.Enter())
+                {
+                    if (IsDisposing || IsDisposed)
+                    {
+                        throw new ObjectDisposedException(nameof(PrimitiveObjectPool<T>));
+                    }
+
+                    m_internalStorage.Add(item); //This will increment storage bag count
+                    Size++;
+                }
             }
         }
+        #endregion
     }
 }

--- a/src/PBase/Collections/ResizablePrimitiveObjectPool.cs
+++ b/src/PBase/Collections/ResizablePrimitiveObjectPool.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace PBase.Collections
+{
+    public class ResizablePrimitiveObjectPool<T> : PrimitiveObjectPool<T> where T : class, new()
+    {
+        public ResizablePrimitiveObjectPool(int size) : base(size) {}
+        
+        public override T Obtain()
+        {
+            if (TryObtain(out T item))
+            {
+                return item;
+            }
+            else
+            {
+                InUse++;
+                Size++;
+                return new T();
+            }
+        }
+
+        public override void Release(T item)
+        {
+            if (!TryRelease(item)) //if pool is full
+            {
+                m_internalStorage.Add(item);
+                Size++;
+            }
+        }
+    }
+}

--- a/src/PBase/Collections/ResizablePrimitiveObjectPool.cs
+++ b/src/PBase/Collections/ResizablePrimitiveObjectPool.cs
@@ -3,13 +3,27 @@ using System.Collections.Concurrent;
 
 namespace PBase.Collections
 {
+    /// <summary>
+    /// <c>ResizeablePrimitiveObjectPool</c> increases pool size when obtaining on empty pool and releasing on full pool
+    /// </summary>
+    /// <typeparam name="T"><c>T</c> must be a class with a parameterless constructor</typeparam>
     public class ResizablePrimitiveObjectPool<T> : PrimitiveObjectPool<T> where T : class, new()
     {
         #region Constructor
+        /// <summary>
+        /// Create a <c>ResizeablePrimitiveObjectPool</c> that increase pool size instead of throwing an <c>ArgumentOutOfRangeException</c>
+        /// </summary>
+        /// <param name="size">the number of objects this object pool will initially hold</param>
+        /// <exception cref="ArgumentOutOfRangeException">throws if <c>size</c> parameter is less than 1</exception>
         public ResizablePrimitiveObjectPool(int size) : base(size) {}
         #endregion
 
         #region Overridden Obtain and Release methods
+        /// <summary>
+        /// <c>Obtain</c> and remove an object from the pool - increases pool size if the pool is empty
+        /// </summary>
+        /// <returns>returns an object of type <typeparamref name="T"/> from the pool</returns>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public override T Obtain()
         {
             if (TryObtain(out T item))
@@ -32,6 +46,11 @@ namespace PBase.Collections
             }
         }
 
+        /// <summary>
+        /// <c>Release</c> an object and add it back into the pool - increases pool size if the pool is full
+        /// </summary>
+        /// <param name="item">the object released back into the pool</param>
+        /// <exception cref="ObjectDisposedException">throws when accessed during or after disposal</exception>
         public override void Release(T item)
         {
             if (!TryRelease(item)) //Tf the pool is full


### PR DESCRIPTION
Three implementations of a Primitive Object Pool: - default, Resizeable and Blocking for different approaches when obtaining on empty pool or releasing on full pool.

Default throws Invalid Operation exception.
Resizeable increases the pool size.
Blocking blocking threads until an item can be obtained or an item can be released as appropriate.

There are TryObtain and TryRelease methods that returns true on success and always return false on failure instead of above behaviour.

Possible additions:
 - configurable timeouts and cancellation tokens for Blocking Primitive Pool
 - trimming pool size for Resizeable Primitive Pool